### PR TITLE
TST noarch outputs

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: osx
   pool:
-    vmImage: macOS-10.13
+    vmImage: macOS-10.14
   timeoutInMinutes: 360
   strategy:
     maxParallel: 8
@@ -20,14 +20,6 @@ jobs:
       echo "Fast Finish"
       
 
-  - script: |
-      echo "Removing homebrew from Azure to avoid conflicts."
-      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
-      chmod +x ~/uninstall_homebrew
-      ~/uninstall_homebrew -fq
-      rm ~/uninstall_homebrew
-    displayName: Remove homebrew
-
   - bash: |
       echo "##vso[task.prependpath]$CONDA/bin"
       sudo chown -R $USER $CONDA
@@ -35,41 +27,46 @@ jobs:
 
   - script: |
       source activate base
-      conda install -n base -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build
-    displayName: 'Add conda-forge-ci-setup=2'
-
-  - script: |
-      source activate base
       echo "Configuring conda."
 
-      setup_conda_rc ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      conda install -c conda-forge --quiet --yes conda-forge-ci-setup=2 conda-build pip
+      conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
+
+      setup_conda_rc ./ "./recipe" ./.ci_support/${CONFIG}.yaml
       export CI=azure
       source run_conda_forge_build_setup
-      conda update --yes --quiet --override-channels -c conda-forge -c defaults --all
+
     env: {
       OSX_FORCE_SDK_DOWNLOAD: "1"
     }
-    displayName: Configure conda and conda-build
+    displayName: 'Configure conda, conda-build, and add conda-forge-ci-setup=2'
+
+  - script: |
+      echo "Mangling homebrew from Azure to avoid conflicts."
+      source activate base
+      /usr/bin/sudo mangle_homebrew
+      /usr/bin/sudo -k
+    displayName: Mangle homebrew
 
   - script: |
       source activate base
-      mangle_compiler ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      mangle_compiler ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Mangle compiler
 
   - script: |
       source activate base
-      make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      make_build_number ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Generate build number clobber file
 
   - script: |
       source activate base
-      conda build ./recipe -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
+      conda build "./recipe" -m ./.ci_support/${CONFIG}.yaml --clobber-file ./.ci_support/clobber_${CONFIG}.yaml
     displayName: Build recipe
 
   - script: |
       source activate base
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
-      upload_package ./ ./recipe ./.ci_support/${CONFIG}.yaml
+      upload_package ./ "./recipe" ./.ci_support/${CONFIG}.yaml
     displayName: Upload package
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -27,8 +27,7 @@ pin_run_as_build:
   zlib:
     max_pin: x.x
 python:
-- '2.7'
-- '3.6'
-- '3.7'
+- 3.6.* *_cpython
+- 3.7.* *_cpython
 zlib:
 - '1.2'

--- a/.noarch_outputs.yaml
+++ b/.noarch_outputs.yaml
@@ -1,0 +1,6 @@
+brial-1.2.7-pyh9f0ad1d_1:
+  ci: azure
+  subdir: linux-64
+brial-1.2.7-pyhc8dfbb8_1:
+  ci: azure
+  subdir: linux-64

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -19,7 +19,8 @@ conda-build:
 
 CONDARC
 
-conda install --yes --quiet conda-forge-ci-setup=2 conda-build -c conda-forge
+conda install --yes --quiet conda-forge-ci-setup=2 conda-build pip -c conda-forge
+
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"


### PR DESCRIPTION
This PR tests if we can use the rendered info in smithy to record and resolve duplicate noarch outputs.

The output from azure is

```bash
BUILD START: ['libbrial-1.2.7-hf4f5a66_1.tar.bz2', 'brial-1.2.7-pyhc8dfbb8_1.tar.bz2', 'brial-1.2.7-pyh9f0ad1d_1.tar.bz2']
```

which matches the noarch builds from smithy

```yaml
brial-1.2.7-pyh9f0ad1d_1:
  ci: azure
  subdir: linux-64
brial-1.2.7-pyhc8dfbb8_1:
  ci: azure
  subdir: linux-64
```

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
